### PR TITLE
Fix typo in README regarding the extension configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Apksize is configurable via a Gradle extension (shown with default values):
 
 in `app/build.gradle`:
 ```groovy
-dexcount {
+apkSize {
     maxApkSize = 5800000
 }
 ```


### PR DESCRIPTION
Fixes #52. Thanks again for the feature @jaredsburrows and your cool talk at the Gradle Summit.