### PR TITLE
Add teamcity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ apkSize {
 
 Configurable flags:
 - `maxApkSize`: Set the max APK size in Kb. Greater than specified size will fail the build. Default is -1.
-- `teamcity` : Enable teamcity statistics ready log output.
+- `teamcity` : Enable teamcity statistics ready log output. Default is true if run on teamcity otherwise default is false.
 
 ## Teamcity
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,25 @@ Apksize is configurable via a Gradle extension (shown with default values) in `a
 ```groovy
 apkSize {
   maxApkSize = 5800000
+  teamcity = true
 }
 ```
 
 Configurable flags:
 - `maxApkSize`: Set the max APK size in Kb. Greater than specified size will fail the build. Default is -1.
+- `teamcity` : Enable teamcity statistics ready log output.
+
+## Teamcity
+
+This will print logs in the form of
+```
+##teamcity[buildStatisticValue key='ApkSize_${apk.name}_B' value='{size in bytes}']
+##teamcity[buildStatisticValue key='ApkSize_${apk.name}_MB' value='{size in megabytes}']
+```
+
+see https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity for
+an in depth explanation how it works
+
 
 # License
 

--- a/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeExtension.kt
+++ b/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeExtension.kt
@@ -5,5 +5,15 @@ open class ApkSizeExtension {
    * Set the max APK size in Kb. Greater than specified size will fail the build. Default is -1.
    */
   var maxApkSize = -1
+
+  /**
+   * Enable this to get teamcity ready statistic reporting in your logs
+   * This will print logs in the form of
+   * ##teamcity[buildStatisticValue key='ApkSize_${apk.name}_B' value='{size in bytes}']
+   * ##teamcity[buildStatisticValue key='ApkSize_${apk.name}_MB' value='{size in megabytes}']
+   *
+   * see https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity for
+   * an in depth explanation how it works
+   */
   var teamcity = false
 }

--- a/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeExtension.kt
+++ b/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeExtension.kt
@@ -5,4 +5,5 @@ open class ApkSizeExtension {
    * Set the max APK size in Kb. Greater than specified size will fail the build. Default is -1.
    */
   var maxApkSize = -1
+  var teamcity = false
 }

--- a/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeExtension.kt
+++ b/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeExtension.kt
@@ -15,5 +15,5 @@ open class ApkSizeExtension {
    * see https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity for
    * an in depth explanation how it works
    */
-  var teamcity = false
+  var teamcity = System.getenv("TEAMCITY_VERSION") != null
 }

--- a/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeTask.kt
+++ b/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeTask.kt
@@ -20,6 +20,7 @@ open class ApkSizeTask : DefaultTask() {
 
     val fileEnding = apk.extension.toUpperCase(Locale.US)
     logger.log(LogLevel.LIFECYCLE, "Total $fileEnding Size in ${apk.name} in bytes: $apkSize (${ApkSizeTools.convertBytesToMegaBytes(apkSize)} mb)")
+
     if (extension.teamcity) {
       logger.log(LogLevel.LIFECYCLE, "##teamcity[buildStatisticValue key='ApkSize_${apk.name}_B' value='$apkSize']")
       logger.log(LogLevel.LIFECYCLE, "##teamcity[buildStatisticValue key='ApkSize_${apk.name}_MB' value='${ApkSizeTools.convertBytesToMegaBytes(apkSize)}']")

--- a/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeTask.kt
+++ b/src/main/kotlin/com/vanniktech/android/apk/size/ApkSizeTask.kt
@@ -20,6 +20,10 @@ open class ApkSizeTask : DefaultTask() {
 
     val fileEnding = apk.extension.toUpperCase(Locale.US)
     logger.log(LogLevel.LIFECYCLE, "Total $fileEnding Size in ${apk.name} in bytes: $apkSize (${ApkSizeTools.convertBytesToMegaBytes(apkSize)} mb)")
+    if (extension.teamcity) {
+      logger.log(LogLevel.LIFECYCLE, "##teamcity[buildStatisticValue key='ApkSize_${apk.name}_B' value='$apkSize']")
+      logger.log(LogLevel.LIFECYCLE, "##teamcity[buildStatisticValue key='ApkSize_${apk.name}_MB' value='${ApkSizeTools.convertBytesToMegaBytes(apkSize)}']")
+    }
 
     outputFile.parentFile.mkdirs()
     outputFile.createNewFile()


### PR DESCRIPTION
I added support for automatic teamcity statistics and visualization so it's easier to track size across builds. It's configuarable and defaults to disabled. 